### PR TITLE
Add service collection extensions

### DIFF
--- a/DeepL/DeepL.csproj
+++ b/DeepL/DeepL.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>

--- a/DeepL/ServiceCollectionExtensions.cs
+++ b/DeepL/ServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2022 DeepL SE (https://www.deepl.com)
+// Use of this source code is governed by an MIT
+// license that can be found in the LICENSE file.
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DeepL {
+  public static class ServiceCollectionExtensions {
+    public static IServiceCollection AddDeepL(
+          this IServiceCollection services,
+          IConfiguration configuration,
+          Action<TranslatorOptions>? configureOptions = null) {
+      if (services is null) throw new ArgumentNullException(nameof(services));
+      if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+
+      services.Configure<TranslatorOptions>(options =>
+      {
+        configuration.GetSection("DeepL").Bind(options);
+        configureOptions?.Invoke(options);
+      });
+
+      services.AddScoped<ITranslator, Translator>();
+
+      return services;
+    }
+  }
+}

--- a/DeepL/Translator.cs
+++ b/DeepL/Translator.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DeepL.Internal;
 using DeepL.Model;
+using Microsoft.Extensions.Options;
 
 namespace DeepL {
 
@@ -415,6 +416,10 @@ namespace DeepL {
 
     /// <summary>Internal class implementing HTTP requests.</summary>
     private readonly DeepLClient _client;
+
+    /// <summary>Initializes a new <see cref="Translator" /> object using your <see cref="TranslatorOptions" />.</summary>
+    /// <param name="options">Options to setup and control Translator behaviour.</param>
+    public Translator(IOptions<TranslatorOptions> options) : this(options.Value.AuthKey ?? "", options.Value) { }
 
     /// <summary>Initializes a new <see cref="Translator" /> object using your authentication key.</summary>
     /// <param name="authKey">
@@ -851,7 +856,7 @@ namespace DeepL {
     ///   system and language runtime version.
     /// </summary>
     /// <param name="sendPlatformInfo">
-    ///   <c>true</c> to send platform information with every API request (default), 
+    ///   <c>true</c> to send platform information with every API request (default),
     ///   <c>false</c> to only send the library version.
     /// </param>
     /// <param name="AppInfo">

--- a/DeepL/TranslatorOptions.cs
+++ b/DeepL/TranslatorOptions.cs
@@ -10,6 +10,10 @@ namespace DeepL {
   /// <summary>Class containing containing options controlling <see cref="Translator" /> behaviour.</summary>
   public sealed class TranslatorOptions {
     /// <summary>
+    ///   Authentication key to access the API.
+    /// </summary>
+    public string? AuthKey { get; set; }
+    /// <summary>
     ///   HTTP headers attached to every HTTP request. By default no extra headers are used. Note that during
     ///   <see cref="Translator" /> initialization headers for Authorization and User-Agent are added, unless they are
     ///   overridden in this option.


### PR DESCRIPTION
## Description
I had some time to play around with the deepl-client (you did an awesome job by the way) and I thought it may be useful to add a set of  `ServiceCollection` extensions to streamline `Translator` usage combined with the `.NET` built-in dependency injection pipeline (probably related to the #26 issue).

In this PR I wrote a small POC, and here's how to use it:

### configuration
```csharp
// create a new service collection or use the .NET built-in one
var services = new ServiceCollection();

// load configuration from JSON files or environment variables
var config = LoadConfiguration();

// use the new `AddDeepL`
services.AddDeepL(config, options =>
{
    // and override the options based on your preferences
    options.appInfo = new AppInfo
    {
        AppName = "test-app",
        AppVersion = "0.0.1",
    };
});
```

### actual usage
```csharp
public class MyClass
{
    private readonly ITranslator _translator;

    public Impl(ITranslator translator)
    {
        _translator = translator;
    }

    public async Task<string> Translate()
    {
        const string sourceText = "Hello world!";
        return await _translator.TranslateTextAsync(sourceText, LanguageCode.English, LanguageCode.Italian);
    }
}
```