### PR TITLE
Remove alpha label from context parameter in README

### DIFF
--- a/DeepL/TextTranslateOptions.cs
+++ b/DeepL/TextTranslateOptions.cs
@@ -21,8 +21,8 @@ namespace DeepL {
     }
 
     /// <summary>
-    /// Specifies additional context to influence translations, that is not translated itself. Note this is an **alpha
-    /// feature**: it may be deprecated at any time, or incur charges if it becomes generally available.
+    /// Specifies additional context to influence translations, that is not translated itself.
+    /// Characters in the `context` parameter are not counted toward billing.
     /// See the API documentation for more information and example usage.
     /// </summary>
     public string? Context { get; set; }

--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ foreach (var formality in new[] { Formality.Less, Formality.More }) {
 - `GlossaryId`: specifies a glossary to use with translation, as a string
   containing the glossary ID.
 - `Context`: specifies additional context to influence translations, that is not
-  translated itself. Note this is an **alpha feature**: it may be deprecated at
-  any time, or incur charges if it becomes generally available.
+  translated itself. Characters in the `context` parameter are not counted toward billing.
   See the [API documentation][api-docs-context-param] for more information and
   example usage.
 - `TagHandling`: type of tags to parse before translation, options are


### PR DESCRIPTION
The `context` parameter is no longer an alpha feature and is generally available. This PR updates the README to reflect this change.