### PR TITLE
docs: Added using statement to document translation in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,11 @@ that case the input file name (or extension) is required, so the DeepL API can
 determine the file type:
 ```c#
 ...
+  using outputFile = File.OpenWrite(outputDocumentPath);
   await translator.TranslateDocumentAsync(
         new MemoryStream(buffer),
         "Input file.docx", // An extension like ".docx" is also sufficient
-        File.OpenWrite(outputDocumentPath),
+        outputFile,
         "EN",
         "DE",
         new DocumentTranslateOptions { Formality = Formality.More });


### PR DESCRIPTION
This PR contains a small fix, that includes the `using` statement to the document translation section of the README.

The reason I think this fix is needed is because without it the output file is empty after the translation.
Even if the fix is easy to make in the code, I think having a bit more precise example would benefit the documentation.

